### PR TITLE
ipstools/vivado_defines.py: adjust for new constant name

### DIFF
--- a/ipstools/vivado_defines.py
+++ b/ipstools/vivado_defines.py
@@ -10,7 +10,7 @@
 # of the BSD license.  See the LICENSE file for details.
 #
 
-VIVADO_PREAMBLE = """if ![info exists PULP_HSA_SIM] {
+VIVADO_PREAMBLE = """if ![info exists PULP_FPGA_SIM] {
     set RTL %s/%s
     set IPS %s/%s
     set FPGA_IPS ../ips


### PR DESCRIPTION
In the process of the HERO release, I cleaned up the repositories and also renamed/harmonized some constants. Unfortunately, this also has a minor impact on IPApproX, which is fixed using this commit.
