### PR TITLE
Add xcelium flist

### DIFF
--- a/ipstools/IPConfig.py
+++ b/ipstools/IPConfig.py
@@ -91,6 +91,11 @@ class IPConfig(object):
             analyze_script += self.sub_ips[s].export_cadence(self.ip_path, target_tech=target_tech, source=source)
         return analyze_script
 
+    def export_ncsim(self, abs_path):
+        ncsim_script = ""
+        for s in self.sub_ips.keys():
+            ncsim_script += self.sub_ips[s].export_ncsim(abs_path)
+        return ncsim_script
 
     def export_vivado(self, abs_path):
         vivado_script = ""

--- a/ipstools/IPDatabase.py
+++ b/ipstools/IPDatabase.py
@@ -896,6 +896,46 @@ class IPDatabase(object):
         with open(filename, "w") as f:
             f.write(vsim_tcl)
 
+    def generate_ncsim_command_list(self, script_path="./src_files.f", root='.', source='ips', domain=None, alternatives=[]):
+        """Exports command script to be used for compilation and elaboration in ncsim or Xcelium.
+
+            :param script_path:           The path where the command file is placed relative to the root variable
+            :type  script_path: str
+
+            :param root:                  The path to which the script is placed relative to. By default the current directory.
+            :type  root: str
+
+            :param domain:                If not None, the domain to be targeting for script generation
+            :type  domain: str or None
+
+            :param alternatives:          If not empty, the list of alternative IPs to be actually used.
+            :type  alternatives: list
+
+        This function exports command scripts to be used for simulation with ncsim or Xcelium.
+        """
+        if source not in ALLOWED_SOURCES:
+            print(tcolors.ERROR + "ERROR: export_make() accepts source='ips' or source='rtl', check generate_scripts.py." + tcolors.ENDC)
+            sys.exit(1)
+        if source=='ips':
+            ip_dic = self.ip_dic
+            # abs_path = '$IPS'
+            abs_path = os.path.abspath(root) + '/' + self.ips_dir
+        elif source=='rtl':
+            ip_dic = self.rtl_dic
+            #abs_path = '$RTL'
+            abs_path = os.path.abspath(root) + '/'+ self.rtl_dir
+        filename = "%s" % (script_path)
+        ncsim_script = ""
+        for i in ip_dic.keys():
+            if ip_dic[i].alternatives==None or set.intersection(set([ip_dic[i].ip_name]), set(alternatives), set(ip_dic[i].alternatives))!=set([]):
+                try:
+                    if domain==None or domain in ip_dic[i].domain:
+                        ncsim_script += ip_dic[i].export_ncsim(abs_path)
+                except TypeError:
+                    ncsim_script += ip_dic[i].export_ncsim(abs_path)
+        with open(filename, "w") as f:
+            f.write(ncsim_script)
+
     def generate_ncelab_list(self, filename, source='ips'):
         """Exports the `ncelab.list` list.
                  

--- a/ipstools/SubIPConfig.py
+++ b/ipstools/SubIPConfig.py
@@ -275,7 +275,23 @@ class SubIPConfig(object):
                 analyze_cmd += CADENCE_ANALYZE_VHDL_CMD % (self.sub_ip_name, source.upper(), "%s/%s" % (path, f))
         return analyze_cmd
 
+    def export_ncsim(self, abs_path):
+        if not ("all" in self.targets or "rtl" in self.targets):
+            return ""
+        if "only_local" in self.flags:
+            return ""
+        if "skip_simulation" in self.flags:
+            return ""
+        ncsim_files = ""
+        if len(self.incdirs) > 0:
+            for i in self.incdirs:
+                ncsim_files +="-incdir "
+                ncsim_files += "%s/%s/%s\n" % (abs_path, self.ip_path, i)
+        files = self.files
+        for f in files:
+            ncsim_files += "%s/%s/%s\n" % (abs_path, self.ip_path, f)
 
+        return ncsim_files
 
     def export_vivado(self, abs_path):
         if not ("all" in self.targets or "xilinx" in self.targets):

--- a/ipstools/makefile_defines_ncsim.py
+++ b/ipstools/makefile_defines_ncsim.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 #
-# vsim_defines.py
+# makefile_defines_ncsim.py
 # Francesco Conti <f.conti@unibo.it>
+# Robert Balas<balasr@iis.ee.ethz.ch>
 #
 # Copyright (C) 2015-2017 ETH Zurich, University of Bologna
 # All rights reserved.
@@ -12,7 +13,7 @@
 
 # templates for ip.mk scripts
 MKN_PREAMBLE = """#
-# Copyright (C) 2015-2017 ETH Zurich, University of Bologna
+# Copyright (C) 2015-2019 ETH Zurich, University of Bologna
 # All rights reserved.
 #
 # This software may be modified and distributed under the terms
@@ -30,7 +31,7 @@ include ncompile/build.mk
 ncompile-$(IP): $(LIB_PATH)/_nmake
 
 $(LIB_PATH)/_nmake : %s
-	@touch $(LIB_PATH)/_nmake
+	echo $(LIB_PATH)/_nmake
 """
 
 MKN_SUBIPRULE = """ncompile-subip-%s: $(LIB_PATH)/%s.nmake
@@ -38,15 +39,15 @@ MKN_SUBIPRULE = """ncompile-subip-%s: $(LIB_PATH)/%s.nmake
 $(LIB_PATH)/%s.nmake: $(SRC_SVLOG_%s) $(SRC_VHDL_%s)
 	$(call subip_echo,%s)
 	%s
-	@touch $(LIB_PATH)/%s.nmake
+	echo $(LIB_PATH)/%s.nmake
 """
 
-MKN_BUILDCMD_SVLOG = "$(SVLOG_CC) -work $(LIB_NAME) %s $(INCDIR_%s) $(SRC_SVLOG_%s)"
-MKN_BUILDCMD_VLOG  = "$(VLOG_CC) -work $(LIB_NAME) %s $(INCDIR_%s) $(SRC_%s)"
-MKN_BUILDCMD_VHDL  = "$(VHDL_CC) -work $(LIB_NAME) %s $(SRC_VHDL_%s)"
+MKN_BUILDCMD_SVLOG = "$(SVLOG_CC) -makelib ./ncsim_libs %s $(INCDIR_%s) $(SRC_SVLOG_%s) -endlib"
+MKN_BUILDCMD_VLOG  = "$(VLOG_CC) -makelib ./ncsim_libs %s $(INCDIR_%s) $(SRC_SVLOG_%s) -endlib"
+MKN_BUILDCMD_VHDL  = "$(VHDL_CC) -makelib ./ncsim_libs %s $(SRC_VHDL_%s) -endlib"
 
 NCELAB_LIST_PREAMBLE = """#
-# Copyright (C) 2015-2017 ETH Zurich, University of Bologna
+# Copyright (C) 2015-2019 ETH Zurich, University of Bologna
 # All rights reserved.
 #
 # This software may be modified and distributed under the terms


### PR DESCRIPTION
These functions generate a list of absolute paths to all modules of all
ips and accompanying include paths. This list can be passed to
ncsim/xcelium for compilation and elaboration. This "all-in-one"
approach (contrary to module libraries) allows for multi-core
simulations.